### PR TITLE
Fix double dead_ends twice bug

### DIFF
--- a/chinesepostman/eularian.py
+++ b/chinesepostman/eularian.py
@@ -79,8 +79,12 @@ def find_dead_ends(graph):
 
     """
     single_nodes = [k for k, order in graph.node_orders.items() if order == 1]
-    return [x for k in single_nodes for x in graph.edges.values() \
-            if k in (x.head, x.tail)]
+    dead_ends = []
+    for k in single_nodes:
+        for x in graph.edges.values():
+            if k in (x.head, x.tail) and x not in dead_ends:
+                dead_ends.append(x)
+    return dead_ends
 
 
 def build_node_pairs(graph):

--- a/chinesepostman/eularian.py
+++ b/chinesepostman/eularian.py
@@ -79,12 +79,8 @@ def find_dead_ends(graph):
 
     """
     single_nodes = [k for k, order in graph.node_orders.items() if order == 1]
-    dead_ends = []
-    for k in single_nodes:
-        for x in graph.edges.values():
-            if k in (x.head, x.tail) and x not in dead_ends:
-                dead_ends.append(x)
-    return dead_ends
+    return set([x for k in single_nodes for x in graph.edges.values() \
+            if k in (x.head, x.tail)])
 
 
 def build_node_pairs(graph):

--- a/chinesepostman/eularian.py
+++ b/chinesepostman/eularian.py
@@ -166,7 +166,8 @@ def add_new_edges(graph, min_route):
 def make_eularian(graph):
     """ Add necessary paths to the graph such that it becomes Eularian. """
     print('\tDoubling dead_ends')
-    graph.add_edges([x.contents for x in find_dead_ends(graph)])  # Double our dead-ends
+    dead_ends = [x.contents for x in find_dead_ends(graph)]
+    graph.add_edges(dead_ends)  # Double our dead-ends
 
     print('\tBuilding possible odd node pairs')
     node_pairs = list(build_node_pairs(graph))
@@ -182,7 +183,7 @@ def make_eularian(graph):
     print('\tFinding cheapest route')
     cheapest_set, min_route = find_minimum_path_set(pair_sets, pair_solutions)
     print('\tAdding new edges')
-    return add_new_edges(graph, min_route)  # Add our new edges
+    return add_new_edges(graph, min_route), len(dead_ends)  # Add our new edges
 
 if __name__ == '__main__':
     import tests.run_tests

--- a/chinesepostman/network.py
+++ b/chinesepostman/network.py
@@ -187,6 +187,9 @@ class Edge(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash(self.contents)
+
     def __repr__(self):
         return 'Edge({}, {}, {}, {})'.format(self.head, self.tail,
                                              self.weight, self.directed)

--- a/data/data.py
+++ b/data/data.py
@@ -4,6 +4,10 @@ Predefined graphs for testing and experimentation.
 
 """
 
+single = [  # Non-Eularian, single edge
+    (1,2,1)
+]
+
 square = [  # Eularian, simple square
     (1,2,1), (2,3,1), (3,4,1), (4,1,1)
 ]

--- a/main.py
+++ b/main.py
@@ -37,9 +37,9 @@ def main():
     print('{} edges'.format(len(original_graph)))
     if not original_graph.is_eularian:
         print('Converting to Eularian path...')
-        graph = eularian.make_eularian(original_graph)
+        graph, num_dead_ends = eularian.make_eularian(original_graph)
         print('Conversion complete')
-        print('\tAdded {} edges'.format(len(graph) - len(original_graph)))
+        print('\tAdded {} edges'.format(len(graph) - len(original_graph) + num_dead_ends))
         print('\tTotal cost is {}'.format(graph.total_cost))
     else:
         graph = original_graph


### PR DESCRIPTION
When there is only one edge in the graph the edge will be doubled twice instead of once.
Since both nodes of that edge has order == 1, we have to check whether there are duplicates in this case.